### PR TITLE
fix: suppress Sentry noise for yamux `invalid protocol version` (×2440)

### DIFF
--- a/internal/sentry/sentry.go
+++ b/internal/sentry/sentry.go
@@ -21,6 +21,7 @@ var ignoredErrors = []string{
 	"EOF",                                             // Client closed connection without graceful shutdown
 	"broken pipe",                                     // Write to closed connection (client already gone)
 	"use of closed network connection",                // Operation on already closed connection
+	"invalid protocol version",                        // yamux: scanner/bot or outdated CLI client (pre-yamux)
 }
 
 // shouldIgnore checks if an error should be filtered out from Sentry.


### PR DESCRIPTION
## Проблема

Sentry issue `7145531313`: ошибка `*errors.errorString: invalid protocol version` появлялась **2440 раз** в продакшене.

Стектрейс указывал на:
- `server.go:154` — `(*Server).Start.func1`
- `server.go:199` — `(*Server).handleConnection`
- захват через `sentry.CaptureErrorf(err, "Session setup failed for %s", ...)`

## Причина

Ошибка генерируется библиотекой [hashicorp/yamux](https://github.com/hashicorp/yamux) (`ErrInvalidVersion`) внутри `session.Accept()`, когда первый байт входящего фрейма не равен `0x00` (ожидаемая версия протокола yamux).

**Это происходит в двух сценариях:**
1. **Порт-сканеры / боты** — подключаются к порту control plane и шлют HTTP-запрос или просто мусор. Первый байт `'G'` (GET), `'P'` (POST) и т.д. — не `0x00`.
2. **Устаревшие CLI-клиенты** — версии, собранные до того как был введён yamux в протокол, и не отправляющие yamux-хедер вовсе.

Это **ожидаемое поведение** с точки зрения сервера — соединение должно быть отклонено, но не попадать в Sentry.

## Фикс (два уровня защиты)

### 1. `internal/sentry/sentry.go`
Добавлена строка `"invalid protocol version"` в список `ignoredErrors` — по аналогии с уже существующими фильтрами для ботов (`first record does not look like a TLS handshake`, `tls: unsupported SSLv2 handshake received` и т.д.).

### 2. `internal/server/server.go`
В `handleConnection()` добавлена явная проверка ошибки до вызова `sentry.CaptureErrorf`:
- Если ошибка содержит `"invalid protocol version"` — логируется как `WARN` с понятным сообщением (`rejected connection ... incompatible protocol (scanner or outdated client)`)
- Для всех остальных ошибок поведение не изменяется

Это **belt-and-suspenders** подход: даже если кто-то вызовет `setupYamuxSession` из нового места, Sentry-фильтр подхватит ошибку.

## Что не изменилось

- Логика для валидных клиентов не затронута
- Протокол не изменён
- Все остальные ошибки сессии по-прежнему идут в Sentry

## Closes

Sentry issue `7145531313`