### PR TITLE
fix: /metrics endpoint 404 — register route directly in Handler()

### DIFF
--- a/internal/ingress/ingress.go
+++ b/internal/ingress/ingress.go
@@ -187,6 +187,12 @@ func (i *Ingress) Handler() http.Handler {
 		log.Printf("Failed to load templates: %v", err)
 	}
 
+	// Register /metrics as a direct gin route so it's reachable on any host
+	// (app.domain, root domain, etc.) without relying on NoRoute dispatch.
+	if i.DashHandler.AppMetrics != nil {
+		r.GET("/metrics", i.DashHandler.Metrics)
+	}
+
 	// Catch-all handler for Tunnels (and Landing Page)
 	r.NoRoute(i.handleRequest)
 	return r


### PR DESCRIPTION
The /metrics route was only added to serveDashboard (NoRoute dispatch) but Gin never reached NoRoute for app.domain because the path-only match was short-circuiting. Fix: register r.GET("/metrics") directly on the gin engine in Handler() so it always matches regardless of Host.