### PR TITLE
fix: respect custom local_host in client config (addr: host:port)

### DIFF
--- a/internal/client/inspector/server.go
+++ b/internal/client/inspector/server.go
@@ -230,7 +230,11 @@ func (s *Server) handleReplay(w http.ResponseWriter, r *http.Request, idStr stri
 	}
 
 	// Reconstruct the request
-	reqURL := "http://localhost:" + s.localPort + exchange.Request.URL
+	localAddr := s.localPort
+	if !strings.Contains(localAddr, ":") {
+		localAddr = "localhost:" + localAddr
+	}
+	reqURL := "http://" + localAddr + exchange.Request.URL
 	req, err := http.NewRequest(exchange.Request.Method, reqURL, bytes.NewReader([]byte(exchange.Request.Body)))
 	if err != nil {
 		http.Error(w, "Failed to create request: "+err.Error(), http.StatusInternalServerError)
@@ -419,7 +423,11 @@ func handleGlobalReplay(w http.ResponseWriter, r *http.Request, idStr string) {
 	}
 
 	// Reconstruct the request
-	reqURL := "http://localhost:" + port + exchange.Request.URL
+	localAddrGlobal := port
+	if !strings.Contains(localAddrGlobal, ":") {
+		localAddrGlobal = "localhost:" + localAddrGlobal
+	}
+	reqURL := "http://" + localAddrGlobal + exchange.Request.URL
 	req, err := http.NewRequest(exchange.Request.Method, reqURL, bytes.NewReader([]byte(exchange.Request.Body)))
 	if err != nil {
 		http.Error(w, "Failed to create request: "+err.Error(), http.StatusInternalServerError)

--- a/internal/client/tui/tui.go
+++ b/internal/client/tui/tui.go
@@ -452,7 +452,11 @@ func (m Model) renderForwarding() string {
 			}
 
 			url := fmt.Sprintf("%s://%s", t.Scheme, domain)
-			local := fmt.Sprintf("http://localhost:%s", t.LocalPort)
+			localAddr := t.LocalPort
+			if !strings.Contains(localAddr, ":") {
+				localAddr = "localhost:" + localAddr
+			}
+			local := fmt.Sprintf("http://%s", localAddr)
 
 			value := urlStyle.Render(url) + arrowStyle.Render(" -> ") + valueStyle.Render(local)
 			lines = append(lines, labelStyle.Render(label)+value)

--- a/internal/client/tunnel/manager.go
+++ b/internal/client/tunnel/manager.go
@@ -87,7 +87,7 @@ func (tm *TunnelManager) StartAll(ctx context.Context) error {
 	tunnelMap := make(map[string]string)
 	for _, mt := range tm.tunnels {
 		tunnelMap[mt.Subdomain] = mt.LocalPort
-		logger.Info("Configured tunnel '%s': localhost:%s -> %s", mt.Name, mt.LocalPort, mt.Subdomain)
+		logger.Info("Configured tunnel '%s': %s -> %s", mt.Name, resolveLocalAddr(mt.LocalPort), mt.Subdomain)
 	}
 
 	// Create shared tunnel

--- a/internal/client/tunnel/tunnel_test.go
+++ b/internal/client/tunnel/tunnel_test.go
@@ -371,3 +371,23 @@ func TestTLSConfig(t *testing.T) {
 		t.Errorf("expected secure.example.com, got %s", cfg.ServerName)
 	}
 }
+
+func TestResolveLocalAddr(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"3000", "localhost:3000"},
+		{"8080", "localhost:8080"},
+		{"example.test:80", "example.test:80"},
+		{"127.0.0.1:3000", "127.0.0.1:3000"},
+		{"myapp.local:8888", "myapp.local:8888"},
+	}
+
+	for _, tt := range tests {
+		got := resolveLocalAddr(tt.input)
+		if got != tt.want {
+			t.Errorf("resolveLocalAddr(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Проблема

Пользователь (@sogl_coder, issue #5) использует `httpd` с кастомным локальным доменом `example.test:80`. При указании этого адреса в `gopublic.yaml` клиент формировал некорректный адрес `localhost:example.test:80`.

**Корень проблемы:** в `shared.go` при дозвоне к локальному сервису хост захардкоден:
```go
// было:
net.Dial("tcp", "localhost:"+localPort)  // → localhost:example.test:80 ❌

// стало:
net.Dial("tcp", resolveLocalAddr(localPort))  // → example.test:80 ✅
```

## Изменения

- **`tunnel/shared.go`**: добавлена функция `resolveLocalAddr()`; используется в `proxyStream`
- **`tunnel/manager.go`**: лог-строка использует `resolveLocalAddr`
- **`tui/tui.go`**: Forwarding-панель показывает корректный `http://host:port`
- **`inspector/server.go`**: replay-запросы используют правильный адрес

## Логика `resolveLocalAddr`

| Ввод | Результат |
|---|---|
| `3000` | `localhost:3000` (обратная совместимость) |
| `example.test:80` | `example.test:80` ✅ |
| `127.0.0.1:3000` | `127.0.0.1:3000` ✅ |

## Тесты

Добавлен `TestResolveLocalAddr` в `tunnel_test.go`. Все тесты: ✅ `go test ./...`, `go vet ./...` чистые.

Fixes #5