### PR TITLE
fix: verify client TLS certificates by default

### DIFF
--- a/VERIFY.md
+++ b/VERIFY.md
@@ -1,0 +1,8 @@
+# VERIFY.md
+
+## Quick Check
+
+```bash
+go test ./...
+go vet ./...
+```

--- a/internal/client/tunnel/shared.go
+++ b/internal/client/tunnel/shared.go
@@ -150,16 +150,7 @@ func (st *SharedTunnel) Start(ctx context.Context) error {
 		return st.handleSession(ctx, conn, connectStart)
 	}
 
-	// Build TLS config
-	tlsConfig := &tls.Config{}
-	if st.TLSConfig != nil {
-		tlsConfig.InsecureSkipVerify = st.TLSConfig.InsecureSkipVerify
-		if st.TLSConfig.ServerName != "" {
-			tlsConfig.ServerName = st.TLSConfig.ServerName
-		}
-	} else {
-		tlsConfig.InsecureSkipVerify = true
-	}
+	tlsConfig := clientTLSConfig(st.TLSConfig)
 
 	st.publishStatus("dialing", fmt.Sprintf("Connecting to %s (TLS)...", st.ServerAddr))
 	dialer := &net.Dialer{Timeout: dialTimeout}

--- a/internal/client/tunnel/tunnel.go
+++ b/internal/client/tunnel/tunnel.go
@@ -82,6 +82,20 @@ func (t *Tunnel) SetTLSConfig(cfg *TLSConfig) {
 	t.TLSConfig = cfg
 }
 
+func clientTLSConfig(cfg *TLSConfig) *tls.Config {
+	tlsConfig := &tls.Config{}
+	if cfg == nil {
+		return tlsConfig
+	}
+
+	tlsConfig.InsecureSkipVerify = cfg.InsecureSkipVerify
+	if cfg.ServerName != "" {
+		tlsConfig.ServerName = cfg.ServerName
+	}
+
+	return tlsConfig
+}
+
 // SetForce sets the force flag to disconnect existing session.
 func (t *Tunnel) SetForce(force bool) {
 	t.Force = force
@@ -159,17 +173,7 @@ func (t *Tunnel) Start() error {
 		return t.handleSession(conn, connectStart)
 	}
 
-	// Build TLS config
-	tlsConfig := &tls.Config{}
-	if t.TLSConfig != nil {
-		tlsConfig.InsecureSkipVerify = t.TLSConfig.InsecureSkipVerify
-		if t.TLSConfig.ServerName != "" {
-			tlsConfig.ServerName = t.TLSConfig.ServerName
-		}
-	} else {
-		// Default: insecure for backward compatibility (TODO: make secure by default)
-		tlsConfig.InsecureSkipVerify = true
-	}
+	tlsConfig := clientTLSConfig(t.TLSConfig)
 
 	t.publishStatus("dialing", fmt.Sprintf("Connecting to %s (TLS)...", t.ServerAddr))
 	dialer := &net.Dialer{Timeout: dialTimeout}

--- a/internal/client/tunnel/tunnel_test.go
+++ b/internal/client/tunnel/tunnel_test.go
@@ -67,6 +67,28 @@ func TestTunnel_SetTLSConfig(t *testing.T) {
 	}
 }
 
+func TestClientTLSConfig_DefaultVerifiesCertificates(t *testing.T) {
+	cfg := clientTLSConfig(nil)
+
+	if cfg.InsecureSkipVerify {
+		t.Error("default TLS config should verify certificates")
+	}
+}
+
+func TestClientTLSConfig_UsesExplicitConfig(t *testing.T) {
+	cfg := clientTLSConfig(&TLSConfig{
+		InsecureSkipVerify: true,
+		ServerName:         "secure.example.com",
+	})
+
+	if !cfg.InsecureSkipVerify {
+		t.Error("InsecureSkipVerify should follow explicit config")
+	}
+	if cfg.ServerName != "secure.example.com" {
+		t.Errorf("expected secure.example.com, got %s", cfg.ServerName)
+	}
+}
+
 func TestTunnel_BoundDomains(t *testing.T) {
 	tun := NewTunnel("localhost:4443", "token", "3000")
 


### PR DESCRIPTION
## What\n- Added  with the repo quick checks.\n- Reused one client TLS config helper for single and shared tunnel clients.\n- Made client TLS certificate verification the default while preserving explicit insecure override support.\n- Added unit coverage for the default and explicit TLS config paths.\n\n## Why\nThe client previously skipped TLS certificate verification by default for remote servers, which is unsafe outside local development.\n\n## Verification\n- ✅ ?   	gopublic/cmd/client	[no test files]
?   	gopublic/cmd/server	[no test files]
ok  	gopublic/internal/auth	(cached)
?   	gopublic/internal/avatar	[no test files]
ok  	gopublic/internal/client/cli	(cached)
ok  	gopublic/internal/client/config	(cached)
ok  	gopublic/internal/client/events	(cached)
ok  	gopublic/internal/client/inspector	(cached)
?   	gopublic/internal/client/logger	[no test files]
ok  	gopublic/internal/client/stats	(cached)
ok  	gopublic/internal/client/tui	(cached)
ok  	gopublic/internal/client/tunnel	(cached)
?   	gopublic/internal/client/updater	[no test files]
ok  	gopublic/internal/config	(cached)
?   	gopublic/internal/dashboard	[no test files]
ok  	gopublic/internal/errors	(cached)
ok  	gopublic/internal/health	(cached)
ok  	gopublic/internal/ingress	(cached)
ok  	gopublic/internal/logging	(cached)
ok  	gopublic/internal/metrics	(cached)
ok  	gopublic/internal/middleware	(cached)
?   	gopublic/internal/models	[no test files]
?   	gopublic/internal/sentry	[no test files]
ok  	gopublic/internal/server	(cached)
ok  	gopublic/internal/storage	(cached)
?   	gopublic/internal/telegram	[no test files]
?   	gopublic/internal/version	[no test files]
?   	gopublic/pkg/protocol	[no test files]\n- ✅ \n- ✅ \n